### PR TITLE
remove use of react object assign in favor of ES6 Object.assign

### DIFF
--- a/lib/components/visualization/paginator/Paginator.js
+++ b/lib/components/visualization/paginator/Paginator.js
@@ -1,5 +1,4 @@
 var React           = require('react/addons');
-var assign          = require('react/lib/Object.assign');
 var PageList        = require('./PageList');
 var PaginationStore = require('../../../stores/PaginationStore');
 
@@ -94,7 +93,7 @@ var Paginator = React.createClass({
 		};
 
 		// Merge pagination modifiers with previously requested modifiers
-		var allModifiers = assign({}, PaginationStore.getRequestedModifiers(), paginationModifiers);
+		var allModifiers = Object.assign({}, PaginationStore.getRequestedModifiers(), paginationModifiers);
 
 		// Fire action with the merged modifiers to request new data
 		this.props.actionMethod({pagination: allModifiers});

--- a/lib/components/visualization/paginator/PerPageSelector.js
+++ b/lib/components/visualization/paginator/PerPageSelector.js
@@ -1,5 +1,4 @@
 var React           = require('react/addons');
-var assign          = require('react/lib/Object.assign');
 var PerPageOption   = require('./PerPageOption');
 var PaginationStore = require('../../../stores/PaginationStore');
 
@@ -82,7 +81,7 @@ var PerPageSelector = React.createClass({
 		};
 
 		// Merge pagination modifiers with previously requested modifiers
-		var allModifiers = assign({}, PaginationStore.getRequestedModifiers(), paginationModifiers);
+		var allModifiers = Object.assign({}, PaginationStore.getRequestedModifiers(), paginationModifiers);
 
 		// Fire action with the merged modifiers to request new data
 		this.props.actionMethod({pagination: allModifiers});

--- a/lib/stores/AlertStore.js
+++ b/lib/stores/AlertStore.js
@@ -1,5 +1,3 @@
-var assign             = require('react/lib/Object.assign');
-
 var BaseStore          = require('./BaseStore');
 var AppDispatcher      = require('../dispatcher/AppDispatcher');
 var AppActionConstants = require('../constants/AppActionConstants');
@@ -26,7 +24,7 @@ var _alert = {
  * @todo how will this handle multiple error messages
  */
 
-var AlertStore = assign({}, BaseStore, {
+var AlertStore = Object.assign({}, BaseStore, {
 	isError: function () {
 		return _alert.isError;
 	},

--- a/lib/stores/BaseStore.js
+++ b/lib/stores/BaseStore.js
@@ -1,4 +1,3 @@
-var assign        = require('react/lib/Object.assign');
 var EventEmitter  = require('events').EventEmitter;
 var AppDispatcher = require('../dispatcher/AppDispatcher');
 
@@ -11,7 +10,7 @@ var CHANGE_EVENT  = 'change';
  * @memberOf Stores
  * @see {@link Stores}
  */
-var BaseStore = assign({}, EventEmitter.prototype, {
+var BaseStore = Object.assign({}, EventEmitter.prototype, {
 	emitChange: function() {
 		this.emit(CHANGE_EVENT);
 	},

--- a/lib/stores/FormStore.js
+++ b/lib/stores/FormStore.js
@@ -1,6 +1,5 @@
-// Extneral
+// External
 var _                   = require('lodash');
-var assign              = require('react/lib/Object.assign');
 
 // Components
 var AppActionConstants  = require('../constants/AppActionConstants');
@@ -23,7 +22,7 @@ var _typeaheadQueryData = {};
  * @memberOf Stores
  * @see {@link Stores}
  */
-var FormStore = assign({}, BaseStore, {
+var FormStore = Object.assign({}, BaseStore, {
 	getField: function (formKey, fieldKey) {
 		// Find the field value with a path string like 'property1.subProperty'
 		return _.get(_formStore[formKey].resource, fieldKey);

--- a/lib/stores/GeneralCmsStore.js
+++ b/lib/stores/GeneralCmsStore.js
@@ -1,4 +1,3 @@
-var assign             = require('react/lib/Object.assign');
 var BaseStore          = require('./BaseStore');
 var AppDispatcher      = require('../dispatcher/AppDispatcher');
 var AppActionConstants = require('../constants/AppActionConstants');
@@ -17,7 +16,7 @@ var _userProperties = {
  * @see {@link Stores}
  *
  */
-var GeneralCmsStore = assign({}, BaseStore, {
+var GeneralCmsStore = Object.assign({}, BaseStore, {
 	/**
 	 * isEditingForm
 	 * @memberOf Stores.GeneralCmsStore

--- a/lib/stores/ModelStore.js
+++ b/lib/stores/ModelStore.js
@@ -1,4 +1,3 @@
-var assign        = require('react/lib/Object.assign');
 var BaseStore     = require('./BaseStore');
 var EventEmitter  = require('events').EventEmitter;
 var AppDispatcher = require('../dispatcher/AppDispatcher');
@@ -14,7 +13,7 @@ var CHANGE_EVENT  = 'change';
  *
  * @todo Work in progress
  */
-var ModelStore = assign({}, BaseStore, {
+var ModelStore = Object.assign({}, BaseStore, {
 });
 
 module.exports = ModelStore;

--- a/lib/stores/PaginationStore.js
+++ b/lib/stores/PaginationStore.js
@@ -1,6 +1,5 @@
 var AppDispatcher = require('../dispatcher/AppDispatcher');
 var AppActionConstants = require('../constants/AppActionConstants');
-var assign = require('react/lib/Object.assign');
 var BaseStore = require('./BaseStore');
 var QueryHelper = require('../utils/QueryHelper');
 
@@ -21,7 +20,7 @@ var _paginationData = {};
  *
  * @memberOf Stores
  */
-var PaginationStore = assign({}, BaseStore, {
+var PaginationStore = Object.assign({}, BaseStore, {
 	/**
 	 * Pull out the query string
 	 *


### PR DESCRIPTION
React's version of assign was a polyfill for the official ES6 implementation of `Object.assign()`. These changes remove the dependency on React's internal API. 

See issue #13. 