### PR TITLE
npmignore the example directory to reduce the package install size

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -7,6 +7,7 @@ npm-debug.log
 
 node_modules
 documentation
+examples
 
 *.css.map
 


### PR DESCRIPTION
Add the `/example` directory to `npmignore` so it does not get transferred during an npm installation. 