### PR TITLE
Adding a babel plugin to properly compile Object.assign

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -20,6 +20,7 @@ gulp.task('sass', function() {
 gulp.task('js', function() {
     return gulp.src('lib/**/*.js')
         .pipe(babel({
+          plugins: ['babel-plugin-transform-object-assign'],
           presets: ['es2015', 'react']
         }))
         .pipe(uglify())

--- a/lib/components/resource-editing/resource-form/Form.js
+++ b/lib/components/resource-editing/resource-form/Form.js
@@ -47,12 +47,12 @@ var FormStore     = require('../../../stores/FormStore');
 var Form = React.createClass({
 	propTypes: {
 		formKey      : React.PropTypes.string.isRequired, // A unique identifier for this instance of the form component
-		bindResource : React.PropTypes.oneOfType([   // The resource to bind
+		bindResource : React.PropTypes.oneOfType([        // The resource to bind
 			React.PropTypes.object,
 			React.PropTypes.array
 		]).isRequired,
-		onSubmit : React.PropTypes.func,             // An optional submit handler
-		schema   : React.PropTypes.object,
+		onSubmit : React.PropTypes.func,                  // An optional submit handler
+		schema   : React.PropTypes.func,
 		children : React.PropTypes.oneOfType([
 			React.PropTypes.array,
 			React.PropTypes.object

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "autoprefixer": "^6.0.3",
     "babel-core": "^6.3.26",
     "babel-loader": "^6.2.0",
+    "babel-plugin-transform-object-assign": "^6.8.0",
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-react": "^6.3.13",
     "bootstrap": "~3.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mortarjs",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "homepage": "http://mortar.fuzzpro.com",
   "repository": {
     "type": "git",


### PR DESCRIPTION
We previously weren't accounting for `Object.assign` when building for release.  This was causing mortar to fail on older browsers. 

Mortar should now be compatible back to IE 10 (potentially older)