### PR TITLE
Updating Form fields to use props vs state.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -155,8 +155,14 @@
             "afterColon": true
         },
         "multiLine": {
-            "align": "colon",                      // Enforces that objects align on the colon.  Breaks for the longest object.
-            "mode": "minimum"
+            "mode": "minimum",
+            "beforeColon": false,
+            "afterColon": true,
+            "align": {
+                "on": "colon",
+                "beforeColon": true,
+                "afterColon": true
+            }
         }
     }],
     "keyword-spacing": 2,                          // require a space after keywords

--- a/lib/components/resource-editing/resource-form/Checkbox.js
+++ b/lib/components/resource-editing/resource-form/Checkbox.js
@@ -36,40 +36,6 @@ var Checkbox = React.createClass({
 	mixins: [FormUtility],
 
 	/**
-	 * Gets the initial state of the component
-	 *
-	 * @memberOf FormComponents.Checkbox
-	 *
-	 * @return {obj}
-	 */
-	getInitialState: function () {
-		return {
-			fieldValue : [],
-			options    : []
-		};
-	},
-
-	/**
-	 * Calls the FormUtilityMixin's componentDidMount function to handle input changes.
-	 * @see {@link FormUtility}
-	 *
-	 * @return {null}
-	 */
-	componentDidMount: function() {
-		this._componentDidMount();
-	},
-
-	/**
-	 * Calls the FormUtilityMixin's componentWillUnmount function to handle removing change listeners
-	 * @see {@link FormUtility}
-	 *
-	 * @return {null}
-	 */
-	componentWillUnmount: function() {
-		this._componentWillUnmount();
-	},
-
-	/**
 	 * Handle check selection
 	 *
 	 * @memberOf FormComponents.Checkbox
@@ -78,7 +44,7 @@ var Checkbox = React.createClass({
 	 * @return {null}
 	 */
 	customHandleChange: function (event) {
-		var selected = this.state.fieldValue || [],
+		var selected = this._fieldValue() || [],
 			option = this.props.options[event.target.dataset.index],
 			comparisonAttr = this.props.comparisonAttr || null;
 
@@ -121,10 +87,11 @@ var Checkbox = React.createClass({
 			label          = this.props.labelAttribute || 'label';
 
 		return this.props.options.map((option, index) => {
-			var checked = false;
+			let checked = false,
+				value = this._fieldValue();
 
-			if (this.state.fieldValue && this.state.fieldValue.length) {
-				this.state.fieldValue.forEach(function (selection) {
+			if (value && value.length) {
+				value.forEach(function (selection) {
 					if (comparisonAttr) {
 						if (option[comparisonAttr] === selection[comparisonAttr]) {
 							checked =  true;

--- a/lib/components/resource-editing/resource-form/DropdownSelect.js
+++ b/lib/components/resource-editing/resource-form/DropdownSelect.js
@@ -69,8 +69,7 @@ var DropdownSelect = React.createClass({
 
 		return {
 			isValid        : true,
-			expandDropdown : false,
-			fieldValue     : []
+			expandDropdown : false
 		};
 	},
 
@@ -87,7 +86,6 @@ var DropdownSelect = React.createClass({
 	 */
 	componentDidMount: function() {
 		window.addEventListener('click', this.handleClick);
-		this._componentDidMount();
 	},
 
 	/**
@@ -102,7 +100,6 @@ var DropdownSelect = React.createClass({
 	 */
 	componentWillUnmount: function() {
 		window.removeEventListener('click', this.handleClick);
-		this._componentWillUnmount();
 	},
 
 	/**
@@ -121,7 +118,7 @@ var DropdownSelect = React.createClass({
 	 */
 	setSelected: function(option) {
 		if (this.props.multiple) {
-			var selected = this.state.fieldValue || [];
+			var selected = this._fieldValue() || [];
 			selected.push(option);
 
 			// Making sure that there are no duplicate entries in the selected array
@@ -159,7 +156,8 @@ var DropdownSelect = React.createClass({
 	 * @return {null}
 	 */
 	removeOption: function(index) {
-		var selected = this.state.fieldValue;
+		var selected = this._fieldValue();
+
 		if (this.props.multiple) {
 			selected.splice(index, 1);
 		} else if (index === -1) {
@@ -247,7 +245,9 @@ var DropdownSelect = React.createClass({
 	 * @return {jsx}
 	 */
 	displaySelected: function() {
-		if (isEmpty(this.state.fieldValue)) {
+		let value = this._fieldValue();
+
+		if (isEmpty(value)) {
 			return (
 				<div>{this.props.placeholder || 'Make a selection'}</div>
 			);
@@ -259,10 +259,10 @@ var DropdownSelect = React.createClass({
 			selected,
 			displayLabel;
 
-		if (! this.state.fieldValue[0]) {
-			selected = [this.state.fieldValue];
+		if (! value[0]) {
+			selected = [value];
 		} else {
-			selected = this.state.fieldValue;
+			selected = value;
 		}
 
 		if (typeof selected === 'object') {

--- a/lib/components/resource-editing/resource-form/Form.js
+++ b/lib/components/resource-editing/resource-form/Form.js
@@ -350,7 +350,8 @@ var Form = React.createClass({
 				return child;
 			}
 
-			var changeCallback;
+			let changeCallback,
+				resource = FormStore.getResource(self.props.formKey) || {};
 
 			if (children.props && typeof children.props.changeCallback === 'function') {
 				changeCallback = children.props.changeCallback;
@@ -362,7 +363,8 @@ var Form = React.createClass({
 				child = React.cloneElement(child, {
 					changeCallback : changeCallback,
 					bindResource   : self.props.bindResource,
-					formKey        : self.props.formKey
+					formKey        : self.props.formKey,
+					resource       : resource
 				});
 
 				self.formFields[child.props.fieldKey] = {

--- a/lib/components/resource-editing/resource-form/Input.js
+++ b/lib/components/resource-editing/resource-form/Input.js
@@ -15,7 +15,9 @@ var FormUtility    = require('./utils/FormUtilityMixin');
  * @class Input
  * @type {ReactComponent}
  *
+ * @prop {!String}   formKey
  * @prop {!String}   fieldKey
+ * @prop {object}    resource      The value of the entire form
  * @prop {String=}   label
  * @prop {String=}   placeholder
  * @prop {String=}   helpText
@@ -38,6 +40,7 @@ var Input = React.createClass({
 	propTypes: {
 		formKey        : React.PropTypes.string,
 		fieldKey       : React.PropTypes.string.isRequired,
+		resource       : React.PropTypes.object,
 		label          : React.PropTypes.string,
 		placeholder    : React.PropTypes.string,
 		helpText       : React.PropTypes.string,
@@ -68,26 +71,6 @@ var Input = React.createClass({
 			renderCharacterCounter : false,
 			fieldValue             : null
 		};
-	},
-
-	/**
-	 * Calls the FormUtilityMixin's componentDidMount function to handle input changes.
-	 * @see {@link FormUtility}
-	 *
-	 * @return {null}
-	 */
-	componentDidMount: function() {
-		this._componentDidMount();
-	},
-
-	/**
-	 * Calls the FormUtilityMixin's componentWillUnmount function to handle removing change listeners
-	 * @see {@link FormUtility}
-	 *
-	 * @return {null}
-	 */
-	componentWillUnmount: function() {
-		this._componentWillUnmount();
 	},
 
 	/**
@@ -173,7 +156,7 @@ var Input = React.createClass({
 						onChange    = {this.handleInput}
 						onFocus     = {this.handleFocus}
 						onBlur      = {this.handleBlur}
-						value       = {this.props.value     || this.state.fieldValue || ''}
+						value       = {this.props.value     || this._fieldValue() || ''}
 						min         = {this.props.min       || null}
 						max         = {this.props.max       || null}
 						maxLength   = {this.props.max       || null}

--- a/lib/components/resource-editing/resource-form/RadioButtons.js
+++ b/lib/components/resource-editing/resource-form/RadioButtons.js
@@ -46,29 +46,8 @@ var RadioButton = React.createClass({
 	 */
 	getInitialState: function () {
 		return {
-			isValid    : true,
-			fieldValue : {}
+			isValid: true
 		};
-	},
-
-	/**
-	 * Calls the FormUtilityMixin's componentDidMount function to handle input changes.
-	 * @see {@link FormUtility}
-	 *
-	 * @return {null}
-	 */
-	componentDidMount: function() {
-		this._componentDidMount();
-	},
-
-	/**
-	 * Calls the FormUtilityMixin's componentWillUnmount function to handle removing change listeners
-	 * @see {@link FormUtility}
-	 *
-	 * @return {null}
-	 */
-	componentWillUnmount: function() {
-		this._componentWillUnmount();
 	},
 
 	/**
@@ -107,7 +86,7 @@ var RadioButton = React.createClass({
 							type="radio" name={option.name || `${this.props.fieldKey}-option-${index}`} value={value}
 							onChange={this.customHandleChange}
 							data-index={index}
-							checked={_.isEqual(this.state.fieldValue, value)}
+							checked={_.isEqual(this._fieldValue(), value)}
 							disabled={this.props.disabled || false} />
 						<span className="circle"></span>
 						<span className="check"></span>

--- a/lib/components/resource-editing/resource-form/RadioButtons.js
+++ b/lib/components/resource-editing/resource-form/RadioButtons.js
@@ -25,6 +25,7 @@ var FormUtility = require('./utils/FormUtilityMixin');
  */
 var RadioButton = React.createClass({
 	propTypes: {
+		formKey        : React.PropTypes.string,
 		fieldKey       : React.PropTypes.string.isRequired,
 		label          : React.PropTypes.string,
 		valueKey       : React.PropTypes.string,

--- a/lib/components/resource-editing/resource-form/TextArea.js
+++ b/lib/components/resource-editing/resource-form/TextArea.js
@@ -39,13 +39,13 @@ var FormUtility = require('./utils/FormUtilityMixin');
  */
 var TextArea = React.createClass({
 	propTypes: {
-		limit: React.PropTypes.number,
-		label: React.PropTypes.string,
-		placeholder: React.PropTypes.string,
-		helpText: React.PropTypes.string,
-		disabled: React.PropTypes.bool,
-		fieldKey: React.PropTypes.string.isRequired,
-		required: React.PropTypes.bool
+		limit       : React.PropTypes.number,
+		label       : React.PropTypes.string,
+		placeholder : React.PropTypes.string,
+		helpText    : React.PropTypes.string,
+		disabled    : React.PropTypes.bool,
+		fieldKey    : React.PropTypes.string.isRequired,
+		required    : React.PropTypes.bool
 	},
 
 	mixins: [FormUtility],
@@ -59,30 +59,9 @@ var TextArea = React.createClass({
 	 */
 	getInitialState: function () {
 		return {
-			isValid: true,
-			renderCharacterCounter: false,
-			fieldValue: null
+			isValid                : true,
+			renderCharacterCounter : false
 		};
-	},
-
-	/**
-	 * Calls the FormUtilityMixin's componentDidMount function to handle input changes.
-	 * @see {@link FormUtility}
-	 *
-	 * @return {null}
-	 */
-	componentDidMount: function() {
-		this._componentDidMount();
-	},
-
-	/**
-	 * Calls the FormUtilityMixin's componentWillUnmount function to handle removing change listeners
-	 * @see {@link FormUtility}
-	 *
-	 * @return {null}
-	 */
-	componentWillUnmount: function() {
-		this._componentWillUnmount();
 	},
 
 	/**
@@ -150,10 +129,10 @@ var TextArea = React.createClass({
 					onChange={this.handleInput}
 					onFocus={this.handleFocus}
 					onBlur={this.handleBlur}
-					value={this.state.fieldValue || ''} ></textarea>
+					value={this._fieldValue() || ''} ></textarea>
 
 				{this.state.renderCharacterCounter && (
-					<CharacterCount input={this.state.fieldValue} limit={this.props.limit} />
+					<CharacterCount input={this._fieldValue()} limit={this.props.limit} />
 				)}
 
 				{this._shouldRenderHelpBlock(this.props.helpText)}

--- a/lib/components/resource-editing/resource-form/TextArea.js
+++ b/lib/components/resource-editing/resource-form/TextArea.js
@@ -39,13 +39,16 @@ var FormUtility = require('./utils/FormUtilityMixin');
  */
 var TextArea = React.createClass({
 	propTypes: {
-		limit       : React.PropTypes.number,
-		label       : React.PropTypes.string,
-		placeholder : React.PropTypes.string,
-		helpText    : React.PropTypes.string,
-		disabled    : React.PropTypes.bool,
-		fieldKey    : React.PropTypes.string.isRequired,
-		required    : React.PropTypes.bool
+		formKey        : React.PropTypes.string,
+		limit          : React.PropTypes.number,
+		label          : React.PropTypes.string,
+		placeholder    : React.PropTypes.string,
+		helpText       : React.PropTypes.string,
+		disabled       : React.PropTypes.bool,
+		fieldKey       : React.PropTypes.string.isRequired,
+		required       : React.PropTypes.bool,
+		changeCallback : React.PropTypes.func,
+		rows           : React.PropTypes.number
 	},
 
 	mixins: [FormUtility],
@@ -83,7 +86,7 @@ var TextArea = React.createClass({
 	 *
 	 * @memberOf FormComponents.TextArea
 	 *
-	 * @param {event} event
+	 * @param {event} event DOM Event
 	 * @return {null}
 	 */
 	handleBlur: function (event) {
@@ -95,7 +98,7 @@ var TextArea = React.createClass({
 	 *
 	 * @memberOf FormComponents.TextArea
 	 *
-	 * @param  {event} event
+	 * @param  {event} event DOM Event
 	 * @return {null}
 	 */
 	handleFocus: function (event) {

--- a/lib/components/resource-editing/resource-form/Toggle.js
+++ b/lib/components/resource-editing/resource-form/Toggle.js
@@ -19,6 +19,8 @@ var FormKeyMixin = require('../../../mixins/FormKeyMixin');
  * @prop {Boolean=}      checked        A custom checked value if we don't want to rely on fieldValue
  * @prop {Array<string>} mods
  * @prop {Function=}     changeCallback
+ * @prop {String=}       labelBefore    A label to show when the box is unchecked
+ * @prop {String=}       labelAfter     A label to show when the box is checked
  *
  * @memberOf FormComponents
  * @see {@link FormComponents}
@@ -27,11 +29,14 @@ var FormKeyMixin = require('../../../mixins/FormKeyMixin');
 var Toggle = React.createClass({
 	propTypes: {
 		fieldKey       : React.PropTypes.string.isRequired,
+		formKey        : React.PropTypes.string,
 		fieldLabel     : React.PropTypes.string,
 		disabled       : React.PropTypes.bool,
 		mods           : React.PropTypes.array,
 		checked        : React.PropTypes.bool,
-		changeCallback : React.PropTypes.func
+		changeCallback : React.PropTypes.func,
+		labelBefore    : React.PropTypes.string,
+		labelAfter     : React.PropTypes.string
 	},
 
 	mixins: [FormUtility, FormKeyMixin],
@@ -45,9 +50,8 @@ var Toggle = React.createClass({
 	 */
 	getInitialState: function () {
 		return {
-			isValid    : true,
-			fieldValue : null,
-			id         : ''
+			isValid : true,
+			id      : ''
 		};
 	},
 
@@ -71,24 +75,12 @@ var Toggle = React.createClass({
 	/**
 	 * Calls the setFormKey function to handle creating a unique ID.
 	 *
-	 * Also calls the FormUtilityMixin's componentDidMount function to handle input changes.
 	 * @see {@link FormUtility}
 	 *
 	 * @return {null}
 	 */
 	componentDidMount: function() {
 		this._setFormKey();
-		this._componentDidMount();
-	},
-
-	/**
-	 * Calls the FormUtilityMixin's componentWillUnmount function to handle removing change listeners
-	 * @see {@link FormUtility}
-	 *
-	 * @return {null}
-	 */
-	componentWillUnmount: function() {
-		this._componentWillUnmount();
 	},
 
 	/**
@@ -130,7 +122,7 @@ var Toggle = React.createClass({
 
 		let toggleClasses = {
 			'mortar-toggle-switch' : true,
-			'inline'              : this.props.labelBefore || this.props.labelAfter
+			'inline'               : this.props.labelBefore || this.props.labelAfter
 		};
 
 		let labelBeforeClasses, labelAfterClasses;
@@ -138,17 +130,17 @@ var Toggle = React.createClass({
 		if (this.props.labelBefore) {
 			labelBeforeClasses = {
 				'mortar-toggle' : true,
-				'label-before'   : true,
-				'show'          : ( ! this.props.checked && ! this.state.fieldValue ) || false
-			}
+				'label-before'  : true,
+				'show'          : ! this.props.checked && ! this._fieldValue() || false
+			};
 		}
 
 		if (this.props.labelAfter) {
 			labelAfterClasses = {
-				'mortar-toggle': true,
-				'label-after' : true,
-				'show'         : this.props.checked || this.state.fieldValue || false
-			}
+				'mortar-toggle' : true,
+				'label-after'   : true,
+				'show'          : this.props.checked || this._fieldValue() || false
+			};
 		}
 
 		return (
@@ -163,7 +155,8 @@ var Toggle = React.createClass({
 					id       = {this.state.id}
 					type     = "checkbox"
 					onClick  = {this.handleInput}
-					checked  = {this.props.checked || this.state.fieldValue || false}
+					readOnly = {true}
+					checked  = {this.props.checked || this._fieldValue() || false}
 					disabled = {this.props.disabled} />
 
 				<label htmlFor={this.state.id} className={className(toggleClasses)} />

--- a/lib/components/resource-editing/resource-form/TypeAheadInput.js
+++ b/lib/components/resource-editing/resource-form/TypeAheadInput.js
@@ -2,11 +2,10 @@
 var _                    = require('lodash');
 var Fuse                 = require('fuse.js');
 var React                = require('react');
-var isEmpty              = require('../../../utils/isEmpty')
+var isEmpty              = require('../../../utils/isEmpty');
 var className            = require('classnames');
 
 // Components
-var BrForm                = require('./Form');
 var Input                = require('./Input');
 var AppActionConstants   = require('../../../constants/AppActionConstants');
 var ActionTypes          = AppActionConstants.ActionTypes.cms.form;
@@ -88,8 +87,8 @@ var TypeAheadInput = React.createClass({
 			selectDisplay : React.PropTypes.func    // A callback function used to customize the display of query and select values
 		}),
 
-		updateCallback: React.PropTypes.func,
-		debug: React.PropTypes.bool
+		updateCallback : React.PropTypes.func,
+		debug          : React.PropTypes.bool
 	},
 
 	mixins: [FormUtility, FormKeyMixin],
@@ -113,12 +112,12 @@ var TypeAheadInput = React.createClass({
 		}
 
 		return {
-			formKey: '',
-			isValid: true,
-			fieldValue: [],
-			typeAhead: {
-				query: '',
-				queryResults: []
+			formKey    : '',
+			isValid    : true,
+			fieldValue : [],
+			typeAhead  : {
+				query        : '',
+				queryResults : []
 			}
 		};
 	},
@@ -131,13 +130,13 @@ var TypeAheadInput = React.createClass({
 	 * @return {null}
 	 */
 	_clearTypeahead: function() {
-			FormActions.clearTypeaheadQueryData(this.state.formKey);
-			this.setState({
-				typeAhead: {
-					query: '',
-					quertResults: []
-				}
-			});
+		FormActions.clearTypeaheadQueryData(this.state.formKey);
+		this.setState({
+			typeAhead: {
+				query        : '',
+				quertResults : []
+			}
+		});
 	},
 
 	/**
@@ -205,8 +204,8 @@ var TypeAheadInput = React.createClass({
 		}
 
 		this.setState({
-			typeAhead: typeAhead,
-			fieldValue: fieldValue
+			typeAhead  : typeAhead,
+			fieldValue : fieldValue
 		});
 	},
 
@@ -224,7 +223,7 @@ var TypeAheadInput = React.createClass({
 	 * @return {String|Function}
 	 */
 	_getDataLabel: function(element) {
-		return element.dataset.label || this._getDataLabel(element.parentElement)
+		return element.dataset.label || this._getDataLabel(element.parentElement);
 	},
 
 	/**
@@ -249,7 +248,8 @@ var TypeAheadInput = React.createClass({
 		// Get the first return of _.where(), similar to laravel's queryBuilder->first()
 		var option = _.where(this.state.typeAhead.queryResults, searchObject)[0];
 
-		var selected = this.state.fieldValue || [];
+		let selected = this._fieldValue() || [];
+
 		if (typeof selected === 'object') {
 			var isSelected = _.where(selected, searchObject).length > 0;
 		} else {
@@ -308,10 +308,12 @@ var TypeAheadInput = React.createClass({
 	 * @return {null}
 	 */
 	removeSelectedOption: function(resource) {
-		if (resource === this.state.fieldValue) {
+		let value = this._fieldValue();
+
+		if (resource === value) {
 			this.props.changeCallback(this.props.fieldKey, null);
 		} else {
-			var selected = this.state.fieldValue.filter(function(option) {
+			var selected = value.filter(function(option) {
 				return option !== resource;
 			});
 
@@ -327,15 +329,18 @@ var TypeAheadInput = React.createClass({
 	 * @return {*}
 	 */
 	buildSelectedBubbles: function () {
-		if (isEmpty(this.state.fieldValue)) { return }
+		let value = this._fieldValue();
+		if (isEmpty(value)) {
+			return;
+		}
 
 		var options = this.props.options || {},
 			field = options.resultDisplayField || this.props.fields[0],
-			fieldValue = this.state.fieldValue,
+			fieldValue = value,
 			display;
 
 		if (typeof fieldValue === 'object' && fieldValue.length) {
-			return this.state.fieldValue.map(function (option, index) {
+			return value.map(function (option, index) {
 				display = typeof options.selectDisplay === 'function' ? options.selectDisplay(option) : option[field];
 				return (
 					<div key={index} className="selected-option">
@@ -391,7 +396,7 @@ var TypeAheadInput = React.createClass({
 			var searchObject = {};
 			searchObject[field] = result[field];
 
-			var isSelected = _.where(this.state.fieldValue, searchObject).length > 0;
+			var isSelected = _.where(this._fieldValue, searchObject).length > 0;
 			var classes = className({
 				'btn btn-flat btn-sm': ! isSelected,
 				'btn btn-default btn-raised btn-sm': isSelected
@@ -540,9 +545,9 @@ var TypeAheadInput = React.createClass({
 		if (search == '') return [];
 
 		var options = {
-			keys: this.props.fields,
-			threshold: 0.4
-		}
+			keys      : this.props.fields,
+			threshold : 0.4
+		};
 
 		var fuse = new Fuse(array, options);
 		return fuse.search(search);
@@ -574,12 +579,12 @@ var TypeAheadInput = React.createClass({
 
 				<div className="form-group">
 					<div className="typeahead-select" multiple={true} onChange={this.customHandleChange} >
-						{this.state.fieldValue && this.state.fieldValue.length < 1 && this._shouldRenderHelpBlock(this.props.helpText)}
+						{this._fieldValue() && this._fieldValue().length < 1 && this._shouldRenderHelpBlock(this.props.helpText)}
 						{this.buildSelectOptions()}
 					</div>
 				</div>
 			</div>
-		)
+		);
 	}
 });
 

--- a/lib/components/resource-editing/resource-form/TypeAheadInput.js
+++ b/lib/components/resource-editing/resource-form/TypeAheadInput.js
@@ -64,10 +64,13 @@ var FormKeyMixin         = require('../../../mixins/FormKeyMixin');
  */
 var TypeAheadInput = React.createClass({
 	propTypes: {
+		formKey        : React.PropTypes.string,
 		fieldKey       : React.PropTypes.string.isRequired,
+		fields         : React.PropTypes.array,
 		label          : React.PropTypes.string,
 		placeholder    : React.PropTypes.string,
 		helpText       : React.PropTypes.string,
+		changeCallback : React.PropTypes.func,
 		limit          : React.PropTypes.oneOfType([
 			React.PropTypes.number,
 			React.PropTypes.bool
@@ -88,7 +91,8 @@ var TypeAheadInput = React.createClass({
 		}),
 
 		updateCallback : React.PropTypes.func,
-		debug          : React.PropTypes.bool
+		debug          : React.PropTypes.bool,
+		disabled       : React.PropTypes.bool
 	},
 
 	mixins: [FormUtility, FormKeyMixin],
@@ -194,6 +198,8 @@ var TypeAheadInput = React.createClass({
 	 * @memberOf FormComponents.TypeAheadInput
 	 *
 	 * @private
+	 *
+	 * @return {null}
 	 */
 	_onChange: function () {
 		var typeAhead  = this.state.typeAhead,
@@ -326,7 +332,7 @@ var TypeAheadInput = React.createClass({
 	 *
 	 * @memberOf FormComponents.TypeAheadInput
 	 *
-	 * @return {*}
+	 * @return {JSX}
 	 */
 	buildSelectedBubbles: function () {
 		let value = this._fieldValue();
@@ -398,8 +404,8 @@ var TypeAheadInput = React.createClass({
 
 			var isSelected = _.where(this._fieldValue, searchObject).length > 0;
 			var classes = className({
-				'btn btn-flat btn-sm': ! isSelected,
-				'btn btn-default btn-raised btn-sm': isSelected
+				'btn btn-flat btn-sm'               : ! isSelected,
+				'btn btn-default btn-raised btn-sm' : isSelected
 			});
 
 			return (

--- a/lib/components/resource-editing/resource-form/utils/FormUtilityMixin.js
+++ b/lib/components/resource-editing/resource-form/utils/FormUtilityMixin.js
@@ -32,6 +32,16 @@ var FormUtility = {
 	},
 
 	/**
+	 * Gets the field value for this field
+	 *
+	 * @private
+	 * @return {*} The value of this field in the FormStore
+	 */
+	_fieldValue: function() {
+		return _.get(this.props.resource, this.props.fieldKey);
+	},
+
+	/**
 	 * Any time a change is registered to a form, the component will request it's data from the FormStore.
 	 *
 	 * So, any time a form component changes, it will automatically request it's updated data from the FormStore

--- a/lib/components/visualization/tables/TableContainer.js
+++ b/lib/components/visualization/tables/TableContainer.js
@@ -39,7 +39,7 @@ var Table = require('./Table');
  */
 var TableContainer = React.createClass({
 	propTypes: {
-		title    : React.PropTypes.string.isRequired,
+		title    : React.PropTypes.string,
 		data     : React.PropTypes.array.isRequired,
 		dataKeys : React.PropTypes.object.isRequired,
 

--- a/lib/stores/FormStore.js
+++ b/lib/stores/FormStore.js
@@ -45,7 +45,7 @@ var FormStore = Object.assign({}, BaseStore, {
 			return {};
 		}
 
-		return _formStore[formKey].resource;
+		return _.cloneDeep(_formStore[formKey].resource);
 	},
 
 	getCurrentFormKey: function () {

--- a/lib/styles/components/form/_Toggle.scss
+++ b/lib/styles/components/form/_Toggle.scss
@@ -187,7 +187,7 @@ $large-bar-w: 80px;
 
 .mortar-toggle.label-before,
 .mortar-toggle.label-after {
-  opacity: 0;
+  opacity: .25;
   font-weight: 500;
   transition: opacity 0.3s;
   height: 26px;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mortarjs",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "homepage": "http://mortar.fuzzpro.com",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "bootstrap": "~3.3.1",
     "clean-webpack-plugin": "^0.1.6",
     "css-loader": "^0.23.1",
-    "eslint": "^2.4.0",
+    "eslint": "^3.2.2",
     "eslint-plugin-react": "^4.2.3",
     "file-loader": "^0.8.5",
     "gulp": "^3.9.1",


### PR DESCRIPTION
Previously, all form fields would attach their own change listener, so when `FormStore.emitChange()` happened, every field that was mounted would request their data from the store.

Now, the `Form` component is responsible for handling those requests.  Every time a change is made, the `Form` itself will request its own data, and then pass down that values to it's children via `props`.

This is a big improvement because there are now `n` less change listeners on the page (where `n` is the number of form fields on the page).

Also, this fixes a bug where adding new fields to an already registered form was requiring an update before the default values of that field would show since we were not computing a field's state value until the `FormStore` emitted a change.


### Potential improvements

Right now, each field is getting the entire resource passed into it (as a reference) and then using the `FormUtilityMixin`'s `fieldValue` function to get it's own value.  However, on re-render, the `Form` could potentially be responsible for chopping that value up, and passing each field their exact value based on their `fieldKey`.